### PR TITLE
Allow use of paths with spaces on Windows

### DIFF
--- a/easy-rsa/Windows/build-ca-pass.bat
+++ b/easy-rsa/Windows/build-ca-pass.bat
@@ -1,8 +1,8 @@
 @echo off
-cd %HOME%
+cd "%HOME%"
 rem build a request for a cert that will be valid for ten years
-openssl req -days 3650 -new -keyout %KEY_DIR%\%1.key -out %KEY_DIR%\%1.csr -config %KEY_CONFIG%
+openssl req -days 3650 -new -keyout "%KEY_DIR%\%1.key" -out "%KEY_DIR%\%1.csr" -config "%KEY_CONFIG%"
 rem sign the cert request with our ca, creating a cert/key pair
-openssl ca -days 3650 -out %KEY_DIR%\%1.crt -in %KEY_DIR%\%1.csr -config %KEY_CONFIG%
+openssl ca -days 3650 -out "%KEY_DIR%\%1.crt" -in "%KEY_DIR%\%1.csr" -config "%KEY_CONFIG%"
 rem delete any .old files created in this process, to avoid future file creation errors
-del /q %KEY_DIR%\*.old
+del /q "%KEY_DIR%\*.old"

--- a/easy-rsa/Windows/build-ca.bat
+++ b/easy-rsa/Windows/build-ca.bat
@@ -1,4 +1,4 @@
 @echo off
-cd %HOME%
+cd "%HOME%"
 rem build a cert authority valid for ten years, starting now
-openssl req -days 3650 -nodes -new -x509 -keyout %KEY_DIR%\ca.key -out %KEY_DIR%\ca.crt -config %KEY_CONFIG%
+openssl req -days 3650 -nodes -new -x509 -keyout "%KEY_DIR%\ca.key" -out "%KEY_DIR%\ca.crt" -config "%KEY_CONFIG%"

--- a/easy-rsa/Windows/build-dh.bat
+++ b/easy-rsa/Windows/build-dh.bat
@@ -1,4 +1,4 @@
 @echo off
-cd %HOME%
+cd "%HOME%"
 rem build a dh file for the server side
-openssl dhparam -out %KEY_DIR%/dh%KEY_SIZE%.pem %KEY_SIZE%
+openssl dhparam -out "%KEY_DIR%/dh%KEY_SIZE%.pem" %KEY_SIZE%

--- a/easy-rsa/Windows/build-key-pass.bat
+++ b/easy-rsa/Windows/build-key-pass.bat
@@ -1,8 +1,8 @@
 @echo off
-cd %HOME%
+cd "%HOME%"
 rem build a request for a cert that will be valid for ten years
-openssl req -days 3650 -new -keyout %KEY_DIR%\%1.key -out %KEY_DIR%\%1.csr -config %KEY_CONFIG%
+openssl req -days 3650 -new -keyout "%KEY_DIR%\%1.key" -out "%KEY_DIR%\%1.csr" -config "%KEY_CONFIG%"
 rem sign the cert request with our ca, creating a cert/key pair
-openssl ca -days 3650 -out %KEY_DIR%\%1.crt -in %KEY_DIR%\%1.csr -config %KEY_CONFIG%
+openssl ca -days 3650 -out "%KEY_DIR%\%1.crt" -in "%KEY_DIR%\%1.csr" -config "%KEY_CONFIG%"
 rem delete any .old files created in this process, to avoid future file creation errors
-del /q %KEY_DIR%\*.old
+del /q "%KEY_DIR%\*.old"

--- a/easy-rsa/Windows/build-key-pkcs12.bat
+++ b/easy-rsa/Windows/build-key-pkcs12.bat
@@ -1,10 +1,10 @@
 @echo off
-cd %HOME%
+cd "%HOME%"
 rem build a request for a cert that will be valid for ten years
-openssl req -days 3650 -nodes -new -keyout %KEY_DIR%\%1.key -out %KEY_DIR%\%1.csr -config %KEY_CONFIG%
+openssl req -days 3650 -nodes -new -keyout "%KEY_DIR%\%1.key" -out "%KEY_DIR%\%1.csr" -config "%KEY_CONFIG%"
 rem sign the cert request with our ca, creating a cert/key pair
-openssl ca -days 3650 -out %KEY_DIR%\%1.crt -in %KEY_DIR%\%1.csr -config %KEY_CONFIG%
+openssl ca -days 3650 -out "%KEY_DIR%\%1.crt" -in "%KEY_DIR%\%1.csr" -config "%KEY_CONFIG%"
 rem convert the key/cert and embed the ca cert into a pkcs12 file.
-openssl pkcs12 -export -inkey %KEY_DIR%\%1.key -in %KEY_DIR%\%1.crt -certfile %KEY_DIR%\ca.crt -out %KEY_DIR%\%1.p12
+openssl pkcs12 -export -inkey "%KEY_DIR%\%1.key" -in "%KEY_DIR%\%1.crt" -certfile "%KEY_DIR%\ca.crt" -out "%KEY_DIR%\%1.p12"
 rem delete any .old files created in this process, to avoid future file creation errors
-del /q %KEY_DIR%\*.old
+del /q "%KEY_DIR%\*.old"

--- a/easy-rsa/Windows/build-key-server-pass.bat
+++ b/easy-rsa/Windows/build-key-server-pass.bat
@@ -1,8 +1,8 @@
 @echo off
-cd %HOME%
+cd "%HOME%"
 rem build a request for a cert that will be valid for ten years
-openssl req -days 3650 -new -keyout %KEY_DIR%\%1.key -out %KEY_DIR%\%1.csr -config %KEY_CONFIG%
+openssl req -days 3650 -new -keyout "%KEY_DIR%\%1.key" -out "%KEY_DIR%\%1.csr" -config "%KEY_CONFIG%"
 rem sign the cert request with our ca, creating a cert/key pair
-openssl ca -days 3650 -out %KEY_DIR%\%1.crt -in %KEY_DIR%\%1.csr -extensions server -config %KEY_CONFIG%
+openssl ca -days 3650 -out "%KEY_DIR%\%1.crt" -in "%KEY_DIR%\%1.csr" -extensions server -config "%KEY_CONFIG%"
 rem delete any .old files created in this process, to avoid future file creation errors
-del /q %KEY_DIR%\*.old
+del /q "%KEY_DIR%\*.old"

--- a/easy-rsa/Windows/build-key-server.bat
+++ b/easy-rsa/Windows/build-key-server.bat
@@ -1,8 +1,8 @@
 @echo off
-cd %HOME%
+cd "%HOME%"
 rem build a request for a cert that will be valid for ten years
-openssl req -days 3650 -nodes -new -keyout %KEY_DIR%\%1.key -out %KEY_DIR%\%1.csr -config %KEY_CONFIG%
+openssl req -days 3650 -nodes -new -keyout "%KEY_DIR%\%1.key" -out "%KEY_DIR%\%1.csr" -config "%KEY_CONFIG%"
 rem sign the cert request with our ca, creating a cert/key pair
-openssl ca -days 3650 -out %KEY_DIR%\%1.crt -in %KEY_DIR%\%1.csr -extensions server -config %KEY_CONFIG%
+openssl ca -days 3650 -out "%KEY_DIR%\%1.crt" -in "%KEY_DIR%\%1.csr" -extensions server -config "%KEY_CONFIG%"
 rem delete any .old files created in this process, to avoid future file creation errors
-del /q %KEY_DIR%\*.old
+del /q "%KEY_DIR%\*.old"

--- a/easy-rsa/Windows/build-key.bat
+++ b/easy-rsa/Windows/build-key.bat
@@ -1,8 +1,8 @@
 @echo off
-cd %HOME%
+cd "%HOME%"
 rem build a request for a cert that will be valid for ten years
-openssl req -days 3650 -nodes -new -keyout %KEY_DIR%\%1.key -out %KEY_DIR%\%1.csr -config %KEY_CONFIG%
+openssl req -days 3650 -nodes -new -keyout "%KEY_DIR%\%1.key" -out "%KEY_DIR%\%1.csr" -config "%KEY_CONFIG%"
 rem sign the cert request with our ca, creating a cert/key pair
-openssl ca -days 3650 -out %KEY_DIR%\%1.crt -in %KEY_DIR%\%1.csr -config %KEY_CONFIG%
+openssl ca -days 3650 -out "%KEY_DIR%\%1.crt" -in "%KEY_DIR%\%1.csr" -config "%KEY_CONFIG%"
 rem delete any .old files created in this process, to avoid future file creation errors
-del /q %KEY_DIR%\*.old
+del /q "%KEY_DIR%\*.old"

--- a/easy-rsa/Windows/clean-all.bat
+++ b/easy-rsa/Windows/clean-all.bat
@@ -1,13 +1,13 @@
 @echo off
 rem move to the HOME directory specified in VARS script
-cd %HOME%
+cd "%HOME%"
 rem set a temporary KEY_DIR variable
 set d=%KEY_DIR%
 rem delete the KEY_DIR and any subdirs quietly
-rmdir /s /q %d%
+rmdir /s /q "%d%"
 rem make a new KEY_DIR
-mkdir %d%
+mkdir "%d%"
 rem copy in a fesh index file so we begin with an empty database
-copy index.txt.start %d%\index.txt
+copy index.txt.start "%d%\index.txt"
 rem copy in a fresh serial file so we begin generating keys at index 01
-copy serial.start %d%\serial.
+copy serial.start "%d%\serial."

--- a/easy-rsa/Windows/revoke-full.bat
+++ b/easy-rsa/Windows/revoke-full.bat
@@ -1,13 +1,13 @@
 @echo off
-cd %HOME%
+cd "%HOME%"
 rem revoke cert
-openssl ca -revoke %KEY_DIR%\%1.crt -config %KEY_CONFIG%
+openssl ca -revoke "%KEY_DIR%\%1.crt" -config "%KEY_CONFIG%"
 rem generate new crl
-openssl ca -gencrl -out %KEY_DIR%\crl.pem -config %KEY_CONFIG%
+openssl ca -gencrl -out "%KEY_DIR%\crl.pem" -config "%KEY_CONFIG%"
 rem test revocation
 rem first concatinate ca cert with newly generated crl
-copy %KEY_DIR%\ca.crt+%KEY_DIR%\crl.pem %KEY_DIR%\revoke_test_file.pem
+copy "%KEY_DIR%\ca.crt"+"%KEY_DIR%\crl.pem" "%KEY_DIR%\revoke_test_file.pem"
 rem now verify the revocation
-openssl verify -CAfile %KEY_DIR%\revoke_test_file.pem -crl_check %KEY_DIR%\%1.crt
+openssl verify -CAfile "%KEY_DIR%\revoke_test_file.pem" -crl_check "%KEY_DIR%\%1.crt"
 rem delete temporary test file
-del /q %KEY_DIR%\revoke_test_file.pem
+del /q "%KEY_DIR%\revoke_test_file.pem"


### PR DESCRIPTION
The lack of quotes prevents placing easy-rsa into a directory which has spaces in its path, as reported by a user of ours.

These changes have not yet been tested at all, so consider this a discussion-only PR for now. Most of the changes should "just work", but there are a couple places where things could potentially break. I've added separate line comments in to these places.

Suggestions/improvements from people who have had to work with batch scripts are most welcome!