### PR TITLE
Fix a comment

### DIFF
--- a/easy-rsa/Windows/vars.bat.sample
+++ b/easy-rsa/Windows/vars.bat.sample
@@ -23,7 +23,7 @@ rem as well as the one-time DH parms
 rem generation process.
 set DH_KEY_SIZE=2048
 
-# Private key size
+rem Private key size
 set KEY_SIZE=4096
 
 rem These are the default values for fields


### PR DESCRIPTION
The "Private key size" comment started with a # sign. This is not supported by cmd.exe and causes it to stop execution at that line, leaving only a few of the required variables defined. Change to "rem" for it to work properly.