### PR TITLE
Set openssl PATH based on registry registry lookup

### DIFF
--- a/easy-rsa/Windows/vars.bat.sample
+++ b/easy-rsa/Windows/vars.bat.sample
@@ -3,6 +3,12 @@ rem Edit this variable to point to
 rem the openssl.cnf file included
 rem with easy-rsa.
 
+rem Automatically set PATH to openssl.exe
+FOR /F "tokens=2*" %%a IN ('REG QUERY "HKEY_LOCAL_MACHINE\SOFTWARE\OpenVPN"') DO set "PATH=%PATH%;%%b\bin"
+
+rem Alternatively define the PATH to openssl.exe manually
+rem set "PATH=%PATH%;C:\Program Files\OpenVPN\bin"
+
 set HOME=%ProgramFiles%\OpenVPN\easy-rsa
 set KEY_CONFIG=openssl-1.0.0.cnf
 


### PR DESCRIPTION
Recent OpenVPN installers stopped modifying the PATH. This had the unfortunate
side-effect that easy-rsa no longer worked on new OpenVPN installations. To fix
this PATH is now automatically set in vars.bat.sample based on a registry
lookup. This should work in all cases as the registry key is added in the -post
phase of OpenVPN install. Moreover, reg.exe should be available on all the
Windows versions we support. The automated approach should only fail if easy-rsa
is downloaded separately and OpenVPN is not installed. For those cases there is
the manual override option which is commented out by default.

The automatic registry lookup code was written by Ilya Shipitsin. The
commented-out manual fallback option was provided by egroeper on GitHub. Both
options were tested and confirmed to work by Samuli Seppänen.

URL: https://github.com/OpenVPN/easy-rsa/issues/148
URL: https://github.com/OpenVPN/openvpn-build/pull/105
Signed-off-by: Samuli Seppänen <samuli@openvpn.net>