### PR TITLE
Change sha1 to sha256 in server/client cert generation

### DIFF
--- a/easy-rsa/2.0/pkitool
+++ b/easy-rsa/2.0/pkitool
@@ -356,7 +356,7 @@ if [ -d "$KEY_DIR" ] && [ "$KEY_CONFIG" ]; then
 	( [ $DO_REQ -eq 0 ] || $OPENSSL req $BATCH -days $KEY_EXPIRE $NODES_REQ -new -newkey rsa:$KEY_SIZE \
 	        -keyout "$FN.key" -out "$FN.csr" $REQ_EXT -config "$KEY_CONFIG" $PKCS11_ARGS ) && \
 	    ( [ $DO_CA -eq 0 ]  || $OPENSSL ca $BATCH -days $KEY_EXPIRE -out "$FN.crt" \
-	        -in "$FN.csr" $CA_EXT -md sha1 -config "$KEY_CONFIG" ) && \
+	        -in "$FN.csr" $CA_EXT -md sha256 -config "$KEY_CONFIG" ) && \
 	    ( [ $DO_P12 -eq 0 ] || $OPENSSL pkcs12 -export -inkey "$FN.key" \
 	        -in "$FN.crt" -certfile "$CA.crt" -out "$FN.p12" $NODES_P12 ) && \
 	    ( [ $DO_CA -eq 0 -o $DO_P11 -eq 1 ]  || chmod 0600 "$FN.key" ) && \


### PR DESCRIPTION
I encountered a problem where OpenVPN on Android couldn't connect because it deemed my certs "too weak". After searching on the topic, I found that you need to change default_md in openssl.conf to sha256, but unfortunately, that didn't help. I then realised that my client/server certs were sha1 despite the change in the config, and I thought "why not find it in the pkitool and change it", and voila, it worked perfectly!